### PR TITLE
Removed language field in document page from backend (docs-core files)

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/DocumentDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/DocumentDao.java
@@ -120,7 +120,7 @@ public class DocumentDao {
         documentDto.setRights((String) o[i++]);
         documentDto.setCreateTimestamp(((Timestamp) o[i++]).getTime());
         documentDto.setUpdateTimestamp(((Timestamp) o[i++]).getTime());
-        documentDto.setLanguage((String) o[i++]);
+        //documentDto.setLanguage((String) o[i++]);
         documentDto.setShared(((Number) o[i++]).intValue() > 0);
         documentDto.setFileCount(((Number) o[i++]).intValue());
         documentDto.setCreator((String) o[i]);
@@ -214,7 +214,7 @@ public class DocumentDao {
         documentDb.setCoverage(document.getCoverage());
         documentDb.setRights(document.getRights());
         documentDb.setCreateDate(document.getCreateDate());
-        documentDb.setLanguage(document.getLanguage());
+        //documentDb.setLanguage(document.getLanguage());
         documentDb.setFileId(document.getFileId());
         documentDb.setUpdateDate(new Date());
         

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/criteria/DocumentCriteria.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/criteria/DocumentCriteria.java
@@ -66,7 +66,7 @@ public class DocumentCriteria {
     /**
      * Language.
      */
-    private String language;
+    //private String language;
     
     /**
      * Creator ID.
@@ -144,6 +144,7 @@ public class DocumentCriteria {
         this.shared = shared;
     }
 
+    /** 
     public String getLanguage() {
         return language;
     }
@@ -151,7 +152,7 @@ public class DocumentCriteria {
     public void setLanguage(String language) {
         this.language = language;
     }
-
+*/
     public String getCreatorId() {
         return creatorId;
     }

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/dto/DocumentDto.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/dto/DocumentDto.java
@@ -69,7 +69,7 @@ public class DocumentDto {
     /**
      * Language.
      */
-    private String language;
+    //private String language;
     
     /**
      * Creation date.
@@ -224,6 +224,7 @@ public class DocumentDto {
         this.shared = shared;
     }
 
+    /** 
     public String getLanguage() {
         return language;
     }
@@ -231,7 +232,7 @@ public class DocumentDto {
     public void setLanguage(String language) {
         this.language = language;
     }
-
+    */
     public Integer getFileCount() {
         return fileCount;
     }

--- a/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Document.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Document.java
@@ -38,8 +38,8 @@ public class Document implements Loggable {
     /**
      * Language (ISO 639-9).
      */
-    @Column(name = "DOC_LANGUAGE_C", nullable = false, length = 3)
-    private String language;
+    //@Column(name = "DOC_LANGUAGE_C", nullable = false, length = 3)
+    //private String language;
     
     /**
      * Title.
@@ -127,6 +127,7 @@ public class Document implements Loggable {
         this.id = id;
     }
     
+        /**
     public String getLanguage() {
         return language;
     }
@@ -134,7 +135,7 @@ public class Document implements Loggable {
     public void setLanguage(String language) {
         this.language = language;
     }
-    
+    */
     public String getUserId() {
         return userId;
     }

--- a/docs-core/src/main/java/com/sismics/docs/core/service/InboxService.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/service/InboxService.java
@@ -228,7 +228,7 @@ public class InboxService extends AbstractScheduledService {
         document.setSubject(StringUtils.abbreviate(mailContent.getSubject(), 500));
         document.setFormat("EML");
         document.setSource("Inbox");
-        document.setLanguage(ConfigUtil.getConfigStringValue(ConfigType.DEFAULT_LANGUAGE));
+       // document.setLanguage(ConfigUtil.getConfigStringValue(ConfigType.DEFAULT_LANGUAGE));
         if (mailContent.getDate() == null) {
             document.setCreateDate(new Date());
         } else {
@@ -262,7 +262,8 @@ public class InboxService extends AbstractScheduledService {
         // Add files to the document
         for (EmailUtil.FileContent fileContent : mailContent.getFileContentList()) {
             FileUtil.createFile(fileContent.getName(), null, fileContent.getFile(), fileContent.getSize(),
-                    document.getLanguage(), "admin", document.getId());
+                    //document.getLanguage(), 
+                    "admin", document.getId());
         }
 
         if (ConfigUtil.getConfigBooleanValue(ConfigType.INBOX_DELETE_IMPORTED)) {

--- a/docs-core/src/main/java/com/sismics/docs/core/util/FileUtil.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/FileUtil.java
@@ -114,7 +114,9 @@ public class FileUtil {
      * @return File ID
      * @throws Exception e
      */
-    public static String createFile(String name, String previousFileId, Path unencryptedFile, long fileSize, String language, String userId, String documentId) throws Exception {
+    public static String createFile(String name, String previousFileId, Path unencryptedFile, long fileSize, 
+    //String language, 
+    String userId, String documentId) throws Exception {
         // Validate mime type
         String mimeType;
         try {
@@ -196,7 +198,7 @@ public class FileUtil {
         startProcessingFile(fileId);
         FileCreatedAsyncEvent fileCreatedAsyncEvent = new FileCreatedAsyncEvent();
         fileCreatedAsyncEvent.setUserId(userId);
-        fileCreatedAsyncEvent.setLanguage(language);
+       //fileCreatedAsyncEvent.setLanguage(language);
         fileCreatedAsyncEvent.setFileId(file.getId());
         fileCreatedAsyncEvent.setUnencryptedFile(unencryptedFile);
         ThreadLocalContext.get().addAsyncEvent(fileCreatedAsyncEvent);

--- a/docs-core/src/main/java/com/sismics/docs/core/util/PdfUtil.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/PdfUtil.java
@@ -95,9 +95,11 @@ public class PdfUtil {
                     if (!Strings.isNullOrEmpty(documentDto.getRights())) {
                         pdfPage.addText("Rights: " + documentDto.getRights());
                     }
+                    /**
                     pdfPage.addText("Language: " + documentDto.getLanguage())
                         .newLine()
                         .addText("Files in this document : " + fileList.size(), false, DocsPDType1Font.HELVETICA_BOLD, 12);
+                         */
                 }
             }
             

--- a/docs-core/src/main/java/com/sismics/docs/core/util/action/ProcessFilesAction.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/action/ProcessFilesAction.java
@@ -47,7 +47,7 @@ public class ProcessFilesAction implements Action {
                 FileUtil.startProcessingFile(file.getId());
                 FileUpdatedAsyncEvent event = new FileUpdatedAsyncEvent();
                 event.setUserId("admin");
-                event.setLanguage(documentDto.getLanguage());
+                //event.setLanguage(documentDto.getLanguage());
                 event.setFileId(file.getId());
                 event.setUnencryptedFile(unencryptedFile);
                 ThreadLocalContext.get().addAsyncEvent(event);

--- a/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
@@ -240,7 +240,8 @@ public class LuceneIndexingHandler implements IndexingHandler {
         List<String> criteriaList = new ArrayList<>();
         Map<String, String> documentSearchMap = Maps.newHashMap();
 
-        StringBuilder sb = new StringBuilder("select distinct d.DOC_ID_C c0, d.DOC_TITLE_C c1, d.DOC_DESCRIPTION_C c2, d.DOC_CREATEDATE_D c3, d.DOC_LANGUAGE_C c4, d.DOC_IDFILE_C, ");
+        // d.DOC_LANGUAGE_C c4,
+        StringBuilder sb = new StringBuilder("select distinct d.DOC_ID_C c0, d.DOC_TITLE_C c1, d.DOC_DESCRIPTION_C c2, d.DOC_CREATEDATE_D c3,  d.DOC_IDFILE_C, ");
         sb.append(" s.count c5, ");
         sb.append(" f.count c6, ");
         sb.append(" rs2.RTP_ID_C c7, rs2.RTP_NAME_C, d.DOC_UPDATEDATE_D c8 ");
@@ -333,10 +334,12 @@ public class LuceneIndexingHandler implements IndexingHandler {
             parameterMap.put("mimeType", criteria.getMimeType());
             criteriaList.add("f0.FIL_ID_C is not null");
         }
+        /**
         if (criteria.getLanguage() != null) {
             criteriaList.add("d.DOC_LANGUAGE_C = :language");
             parameterMap.put("language", criteria.getLanguage());
         }
+          */
         if (criteria.getCreatorId() != null) {
             criteriaList.add("d.DOC_IDUSER_C = :creatorId");
             parameterMap.put("creatorId", criteria.getCreatorId());
@@ -365,7 +368,7 @@ public class LuceneIndexingHandler implements IndexingHandler {
             documentDto.setTitle((String) o[i++]);
             documentDto.setDescription((String) o[i++]);
             documentDto.setCreateTimestamp(((Timestamp) o[i++]).getTime());
-            documentDto.setLanguage((String) o[i++]);
+            //documentDto.setLanguage((String) o[i++]);
             documentDto.setFileId((String) o[i++]);
             Number shareCount = (Number) o[i++];
             documentDto.setShared(shareCount != null && shareCount.intValue() > 0);

--- a/docs-core/src/test/java/com/sismics/docs/core/util/TestFileUtil.java
+++ b/docs-core/src/test/java/com/sismics/docs/core/util/TestFileUtil.java
@@ -93,7 +93,7 @@ public class TestFileUtil {
             documentDto.setType("Image");
             documentDto.setCoverage("France");
             documentDto.setRights("Public Domain");
-            documentDto.setLanguage("en");
+            //documentDto.setLanguage("en");
             documentDto.setCreator("user1");
             documentDto.setCreateTimestamp(new Date().getTime());
             


### PR DESCRIPTION
Issue #2 

Removed `language` field in document page from backend (docs-core files) by commenting out the lines that contained `language`. Also, the test cases that tested the `language` field were commented out.