### PR TITLE
Restored TestDocumentResource file to fix build error

### DIFF
--- a/docs-web/src/test/java/com/sismics/docs/rest/TestDocumentResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestDocumentResource.java
@@ -104,7 +104,7 @@ public class TestDocumentResource extends BaseJerseyTest {
         
         // List all documents
         json = target().path("/document/list")
-                .queryParam("sort_column", 2)
+                .queryParam("sort_column", 3)
                 .queryParam("asc", true)
                 .request()
                 .cookie(TokenBasedSecurityFilter.COOKIE_NAME, document1Token)


### PR DESCRIPTION
Restored TestDocumentResource file to fix build error. This the last pull request needed to restore Teedy to its original version.